### PR TITLE
GH-13 Add support for credentials helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ From github.com:openshiftio/appdev-documentation
 |`paths`||true|List of paths to be picked up from the repository (will be added to $GIT_DIR/info/sparse-checkout).
 |`outputDirectory`|${project.build.outputDirectory}|false|Directory into which the git content will be checked out|
 |`branch`|master|false|Specifies branch to be checked out|
-|`username`||false|If provided together with `password` and `repository` schema is https these will be used for pull|
-|`pasword`||false|see `username`|
+|`username`||false|If provided and `repository` schema is https it will be added to the url|
+|`pasword`||false|If provided it will be added to the `username` in url. Cannot be provided without `username`|

--- a/src/main/java/com/github/gastaldi/git/URLCredentialsDecorator.java
+++ b/src/main/java/com/github/gastaldi/git/URLCredentialsDecorator.java
@@ -7,6 +7,7 @@ public interface URLCredentialsDecorator {
 
     /**
      * Decorates given url with credentials if present or returns as is when there are no credentials
+     * Credentials will be escaped for url
      *
      * @throws IllegalArgumentException if url is not of https schema
      * @throws IllegalArgumentException if password is provided but no username

--- a/src/main/java/com/github/gastaldi/git/impl/URLCredentialsDecoratorImpl.java
+++ b/src/main/java/com/github/gastaldi/git/impl/URLCredentialsDecoratorImpl.java
@@ -3,7 +3,10 @@ package com.github.gastaldi.git.impl;
 import com.github.gastaldi.git.URLCredentialsDecorator;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Lukas Zaruba, lukas.zaruba@lundegaard.eu, 2019
@@ -31,9 +34,17 @@ public class URLCredentialsDecoratorImpl implements URLCredentialsDecorator {
     }
 
     private String getAuthority(String username, String password) {
-        String authority = username + ":";
+        String authority = encode(username) + ":";
         if (StringUtils.isEmpty(password)) return authority;
-        return authority + password;
+        return authority + encode(password);
+    }
+
+    private String encode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Unknown encoding", e);
+        }
     }
 
 }

--- a/src/test/java/com/github/gastaldi/git/impl/URLCredentialsDecoratorImplTest.java
+++ b/src/test/java/com/github/gastaldi/git/impl/URLCredentialsDecoratorImplTest.java
@@ -44,4 +44,10 @@ class URLCredentialsDecoratorImplTest {
                 .isEqualTo("https://user:pass@github.com/something");
     }
 
+    @Test
+    void usernameAndPasswordEscape() {
+        assertThat(new URLCredentialsDecoratorImpl().decorate(URL, "user@domain.com", "pass&"))
+                .isEqualTo("https://user%40domain.com:pass%26@github.com/something");
+    }
+
 }


### PR DESCRIPTION
Username and password are encoded into the url
Update of the readme to reflect latest changes in the username and password handling